### PR TITLE
更新版本号至 1.1.9

### DIFF
--- a/versions/1.20.1/index.toml
+++ b/versions/1.20.1/index.toml
@@ -185,7 +185,7 @@ metafile = true
 
 [[files]]
 file = "mods/chatpatches.pw.toml"
-hash = "6e2eceacd703ba991364b3300268b4a7f77a7bb6f0b5dfc81904bc24bec3230c"
+hash = "4d91c7d41b52bce8c62dacf4634cc353f67c397b5e26e7dd952923361fd901a1"
 metafile = true
 
 [[files]]
@@ -220,7 +220,7 @@ metafile = true
 
 [[files]]
 file = "mods/default-options.pw.toml"
-hash = "0db6c29bf4627021cbc13945b69b3562a6153ea1be1968ab9a7dd3c6ca08c6b6"
+hash = "6d177676bfb422b8d9e2c7702ec7db9da034dfb93fc4b5817bfdbeb934218850"
 metafile = true
 
 [[files]]
@@ -400,7 +400,7 @@ metafile = true
 
 [[files]]
 file = "mods/magiclib.pw.toml"
-hash = "4a52b6190434f40facd088437865a68a34957991e85ba58149150dde757e33b5"
+hash = "20c1e67836f22d8b23e171ca6a260222a34408b6464042f36114a4261750b235"
 metafile = true
 
 [[files]]
@@ -515,7 +515,7 @@ metafile = true
 
 [[files]]
 file = "mods/polytone.pw.toml"
-hash = "8e91f784e6799face9c6b538f26d5d13a2974db7e3f23f53d3fcc60698f5157a"
+hash = "e05c3f1af4798dfda3c67686753848fe34c933b89831351124be3ec095fe4ac8"
 metafile = true
 
 [[files]]

--- a/versions/1.20.1/mods/chatpatches.pw.toml
+++ b/versions/1.20.1/mods/chatpatches.pw.toml
@@ -1,13 +1,13 @@
 name = "Chat Patches"
-filename = "chatpatches-8.0-alpha.1+1.20.1-fabric.jar"
+filename = "chatpatches-8.0-alpha.2+1.20.1-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/RwzR8odP/chatpatches-8.0-alpha.1%2B1.20.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/NmzcJw1l/chatpatches-8.0-alpha.2%2B1.20.1-fabric.jar"
 hash-format = "sha512"
-hash = "dc91686ee31ce843b6ca4a362a292b188be0d305360b8bf5abf8376d3e1852af7d1b26607ab52c9a79c15235161a19ad08e4a24cc92f836b7f9a67fc58d6fad2"
+hash = "2044bb27944bddd2316d295fc7dc494d7b1ef860f35679426f6cc2cbffca9a3a4a85250c2821bce82a66a1ff8d171b98c3cdfad94077c79a794709058a059e2b"
 
 [update]
 [update.modrinth]
 mod-id = "MOqt4Z5n"
-version = "RwzR8odP"
+version = "NmzcJw1l"

--- a/versions/1.20.1/mods/default-options.pw.toml
+++ b/versions/1.20.1/mods/default-options.pw.toml
@@ -1,13 +1,13 @@
 name = "Default Options"
-filename = "defaultoptions-fabric-1.20.1-18.0.2.jar"
+filename = "defaultoptions-fabric-1.20.1-18.0.3.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/WEg59z5b/versions/zgawi2vw/defaultoptions-fabric-1.20.1-18.0.2.jar"
+url = "https://cdn.modrinth.com/data/WEg59z5b/versions/Mv3kSrRO/defaultoptions-fabric-1.20.1-18.0.3.jar"
 hash-format = "sha512"
-hash = "ea4343e93d97d17d0c58c40eb9f4743cee7dad8d16bc5c684162c4a5d634f8dcd8e40931d3359a4716fec81a6c877ac3622168f1039d072bfb8c97db4c743595"
+hash = "0b4abbea16b74537416cb5efb7da083b70c85aa8253d5714050e94684601f9fc037cbaf929f8940b11a2dda0f8261542fcc2929fda6e6a1b2a41bb92ac12a15d"
 
 [update]
 [update.modrinth]
 mod-id = "WEg59z5b"
-version = "zgawi2vw"
+version = "Mv3kSrRO"

--- a/versions/1.20.1/mods/magiclib.pw.toml
+++ b/versions/1.20.1/mods/magiclib.pw.toml
@@ -1,13 +1,13 @@
 name = "MagicLib Dev"
-filename = "MagicLib-mc1.20.1-fabric-0.8.721-beta.jar"
+filename = "MagicLib-mc1.20.1-fabric-0.8.722-beta.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/JOGZQCse/versions/3aYP2raV/MagicLib-mc1.20.1-fabric-0.8.721-beta.jar"
+url = "https://cdn.modrinth.com/data/JOGZQCse/versions/2zhMKIDB/MagicLib-mc1.20.1-fabric-0.8.722-beta.jar"
 hash-format = "sha512"
-hash = "c9996813de37167c2d56a54dc57500c03a5279a558907f7c26f5e063c3ed0ecbcf85f88f87181002d2572a7e1ec814e5b176ee5208787eee2d166ec15a20f09e"
+hash = "c71b271c127dc96098faae9282394a7274f51b47dc68df31c69264fd9d67ba268a8af54ac84589281a3655a4f21a89882a5f2a4fee04d5a7360183876d4e15f9"
 
 [update]
 [update.modrinth]
 mod-id = "JOGZQCse"
-version = "3aYP2raV"
+version = "2zhMKIDB"

--- a/versions/1.20.1/mods/polytone.pw.toml
+++ b/versions/1.20.1/mods/polytone.pw.toml
@@ -1,13 +1,13 @@
 name = "Polytone"
-filename = "polytone-1.20-3.5.1-fabric.jar"
+filename = "polytone-1.20-3.5.3-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/3qAYkBMB/versions/KXgPOV0u/polytone-1.20-3.5.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/3qAYkBMB/versions/hXkCsi1Y/polytone-1.20-3.5.3-fabric.jar"
 hash-format = "sha512"
-hash = "3bd7b395ef38c6e16b4dd204cde4cdafe1f8f896049dcf0bf6d15c9abbd6ade22950e1a6ca2855909b376473f24e8601afe29bfa26dbd25542ecdcc35133627a"
+hash = "ecf08c43bcb00e6c9399e8fa50e78a0087c26a24ae68311d6a1e91d672d1269eedccb2714fa6c550acb6f8f5b5c962ac1a4b31a1b780fae4db58ccf79e1fc6d3"
 
 [update]
 [update.modrinth]
 mod-id = "3qAYkBMB"
-version = "KXgPOV0u"
+version = "hXkCsi1Y"

--- a/versions/1.20.1/pack.toml
+++ b/versions/1.20.1/pack.toml
@@ -1,12 +1,12 @@
 name = "LunarFox"
 author = "OrzMiku"
-version = "1.1.8+mc1.20.1"
+version = "1.1.9+mc1.20.1"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "682b323b3285ac012ceba827229ac8bac62df977fd7507f39f8f492f588758a1"
+hash = "fbcd8469afee7995af4c7522a136198780b20e4726a56b197df6371684aa0022"
 
 [versions]
 fabric = "0.16.14"

--- a/versions/1.21.1/index.toml
+++ b/versions/1.21.1/index.toml
@@ -148,7 +148,7 @@ metafile = true
 
 [[files]]
 file = "mods/better-selection.pw.toml"
-hash = "1834c4dda40a11f275bb16180e29f505fb27bf0a1adbe69885d88a9990196bd5"
+hash = "5f13e2470d769f613652ff4378a31c86b5915fe67032c94c1be5aeed06610b4d"
 metafile = true
 
 [[files]]
@@ -198,7 +198,7 @@ metafile = true
 
 [[files]]
 file = "mods/chatpatches.pw.toml"
-hash = "330f90d219ef6aa7e5e0f3c63374f5854d5e8ed4846048bc6dcade6d51bdcb9b"
+hash = "54934cbbf4610b440a95d50fedcd76c54dc1aed23944d5660ff647d5ea6221ce"
 metafile = true
 
 [[files]]
@@ -233,7 +233,7 @@ metafile = true
 
 [[files]]
 file = "mods/default-options.pw.toml"
-hash = "58eb5171cd6501d4214111da59a6c22761fc1c192ddf0f76d02de5e7113277e5"
+hash = "28c449d4ceafd79043f9c6e02f408e9f67e59e3e7259ba37a9bc1321a55efe04"
 metafile = true
 
 [[files]]
@@ -403,7 +403,7 @@ metafile = true
 
 [[files]]
 file = "mods/magiclib.pw.toml"
-hash = "40b63645441d55b034ce476d7f67ecf6efb22cf32808791f290c2420b3c1efab"
+hash = "babfa2bd09de71ac69563288830b58f50c1e9e23cb1218ba42b760a54c0a03d4"
 metafile = true
 
 [[files]]
@@ -498,7 +498,7 @@ metafile = true
 
 [[files]]
 file = "mods/packet-fixer.pw.toml"
-hash = "2042bf4b5b3bdd0faafa8310673ab3a6115240f4f36e5e2ff38c7d933e483637"
+hash = "4bf091a6947c83041ae6e9577c9877fbb77908ccf1652d212800132a9eba02ef"
 metafile = true
 
 [[files]]

--- a/versions/1.21.1/mods/better-selection.pw.toml
+++ b/versions/1.21.1/mods/better-selection.pw.toml
@@ -1,13 +1,13 @@
 name = "Better Selection"
-filename = "better-selection-1.6.7.jar"
+filename = "better-selection-1.6.8.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/iZeFi2vX/better-selection-1.6.7.jar"
+url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/XjB8wIwx/better-selection-1.6.8.jar"
 hash-format = "sha512"
-hash = "215b45c43ef391074d651dd835562aa41d3cb5e9ecea6b918e65944ea04b162884767824ba455a693bd51050c011f5a5d7f3711650903e753b77ca9f2b522daa"
+hash = "181c466adcba2f7094c1ef9ff13aea9f79d6306f6f2d2983c97145449b7a9b69d861a0eedba3b30fa181ca20627e02402ef648989b1a6e27c6b77d93e8d91fb7"
 
 [update]
 [update.modrinth]
 mod-id = "xIpcAYJL"
-version = "iZeFi2vX"
+version = "XjB8wIwx"

--- a/versions/1.21.1/mods/chatpatches.pw.toml
+++ b/versions/1.21.1/mods/chatpatches.pw.toml
@@ -1,13 +1,13 @@
 name = "Chat Patches"
-filename = "chatpatches-8.0-alpha.1+1.21.1-fabric.jar"
+filename = "chatpatches-8.0-alpha.2+1.21.1-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/W9oeQ6YV/chatpatches-8.0-alpha.1%2B1.21.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/uHFkyYGX/chatpatches-8.0-alpha.2%2B1.21.1-fabric.jar"
 hash-format = "sha512"
-hash = "3d6d9a979284596cff5904f57068cebee259b1d2e256c74f5a55f3a24a86db5503fbc482a362c8ee64bb1c429223aade99f93af370518101792508c28d113e95"
+hash = "0b0c0c4ab2a833f44f4e6715c8221a1a1d341c771f62f7440204feb6b677ba6d8a77cf28569dfc7f9a2f7e564abe153b31687ceb200c98d139ca574812a9ec1c"
 
 [update]
 [update.modrinth]
 mod-id = "MOqt4Z5n"
-version = "W9oeQ6YV"
+version = "uHFkyYGX"

--- a/versions/1.21.1/mods/default-options.pw.toml
+++ b/versions/1.21.1/mods/default-options.pw.toml
@@ -1,13 +1,13 @@
 name = "Default Options"
-filename = "defaultoptions-fabric-1.21.1-21.1.3.jar"
+filename = "defaultoptions-fabric-1.21.1-21.1.4.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/WEg59z5b/versions/rReL4zP9/defaultoptions-fabric-1.21.1-21.1.3.jar"
+url = "https://cdn.modrinth.com/data/WEg59z5b/versions/WarM6iFt/defaultoptions-fabric-1.21.1-21.1.4.jar"
 hash-format = "sha512"
-hash = "88f6fad70d74ead6dd55cb9a6a0381a3acfbb90be011cb2c961c3b2d027b6a05af48aa0554d6932812d0b82941575dcac18599f3213a603b43b98e8afb17b0cb"
+hash = "3211598d89d4a33be28b0ddcfad5c4d59aebd615b6e7ce483edeed6e9af1230fd4409a556db2b77c3b3670cc333d13a58982021c37740ec60a9fe885ede08a86"
 
 [update]
 [update.modrinth]
 mod-id = "WEg59z5b"
-version = "rReL4zP9"
+version = "WarM6iFt"

--- a/versions/1.21.1/mods/magiclib.pw.toml
+++ b/versions/1.21.1/mods/magiclib.pw.toml
@@ -1,13 +1,13 @@
 name = "MagicLib Dev"
-filename = "MagicLib-mc1.21.1-fabric-0.8.721-beta.jar"
+filename = "MagicLib-mc1.21.1-fabric-0.8.722-beta.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/JOGZQCse/versions/t3IhmMIY/MagicLib-mc1.21.1-fabric-0.8.721-beta.jar"
+url = "https://cdn.modrinth.com/data/JOGZQCse/versions/ZZt07ScD/MagicLib-mc1.21.1-fabric-0.8.722-beta.jar"
 hash-format = "sha512"
-hash = "3161200b12c5a86696256e4ad5b7b90f8c3036c49a3f925a97252484f943bf54536d7b2a4f77f550f91ef51cd1f3d75a764c6f12268fc3f53b9731dc34be14dc"
+hash = "4793e09e416057636f6b56584d4a00aae47045e4585aedb366b0be7867635b508c171eed17fc7e95495d0c87f3e47d04f0b065fa0ba088e1cf50c5e41e9a7f20"
 
 [update]
 [update.modrinth]
 mod-id = "JOGZQCse"
-version = "t3IhmMIY"
+version = "ZZt07ScD"

--- a/versions/1.21.1/mods/packet-fixer.pw.toml
+++ b/versions/1.21.1/mods/packet-fixer.pw.toml
@@ -1,13 +1,13 @@
 name = "Packet Fixer"
-filename = "packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+filename = "packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/c7m1mi73/versions/xIgAknUv/packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+url = "https://cdn.modrinth.com/data/c7m1mi73/versions/LL1w2rTw/packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 hash-format = "sha512"
-hash = "797fe40eb8f1be0d657f44a00a72e2a07dcda88d9e7a6e2f944ae3b6fe70491508410b4748b6c8b55d8f95c5e9867e06ab7b505372b738dbd54f0e74b50d5c82"
+hash = "639c010b5c05e8ec964a8ad1b5736302a02ee03f2f5f97e076df9c5aa23d94b52752e0998356b223f9bbf7c426a433bb89d3a38e24efd062a8de126464f37f59"
 
 [update]
 [update.modrinth]
 mod-id = "c7m1mi73"
-version = "xIgAknUv"
+version = "LL1w2rTw"

--- a/versions/1.21.1/pack.toml
+++ b/versions/1.21.1/pack.toml
@@ -1,12 +1,12 @@
 name = "LunarFox"
 author = "OrzMiku"
-version = "1.1.8+mc1.21.1"
+version = "1.1.9+mc1.21.1"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "82db57b00bf3e8542bb1f69c44cf38b89329e951b9404bec3dd5404a5faa95a0"
+hash = "c4145c0ec97147f481563df359ed4ff845348cebe5d10a40b46ae6f666a215f6"
 
 [versions]
 fabric = "0.16.14"

--- a/versions/1.21.4/index.toml
+++ b/versions/1.21.4/index.toml
@@ -140,7 +140,7 @@ metafile = true
 
 [[files]]
 file = "mods/better-selection.pw.toml"
-hash = "1834c4dda40a11f275bb16180e29f505fb27bf0a1adbe69885d88a9990196bd5"
+hash = "5f13e2470d769f613652ff4378a31c86b5915fe67032c94c1be5aeed06610b4d"
 metafile = true
 
 [[files]]
@@ -190,7 +190,7 @@ metafile = true
 
 [[files]]
 file = "mods/chatpatches.pw.toml"
-hash = "b2473659b637dc60f6c5b3b406b4c084aa0ce42480a545c8bd8053172f1e0c1f"
+hash = "d9cd7269705c074f89d7e0db959f4a9d437a2bbd10f04eb0933f863e2711ca96"
 metafile = true
 
 [[files]]
@@ -220,7 +220,7 @@ metafile = true
 
 [[files]]
 file = "mods/default-options.pw.toml"
-hash = "3cc4abcdc14b5bd7cd34513ad8183f143d8a64cdcbc1181c8235f75ce599771c"
+hash = "c4944e69e27c93b3aa7da2e6f3ce23c223db29217c24118b0a6aed95c13cd871"
 metafile = true
 
 [[files]]
@@ -385,7 +385,7 @@ metafile = true
 
 [[files]]
 file = "mods/magiclib.pw.toml"
-hash = "51e22c83aa33df192fe437e102ddf422a73f3f9dbfd352139ab021a294b697c5"
+hash = "148d76d70b3530351a6a2d3d4e795bef74f8bed3573224e12e95974ce84e0699"
 metafile = true
 
 [[files]]
@@ -480,7 +480,7 @@ metafile = true
 
 [[files]]
 file = "mods/packet-fixer.pw.toml"
-hash = "2042bf4b5b3bdd0faafa8310673ab3a6115240f4f36e5e2ff38c7d933e483637"
+hash = "4bf091a6947c83041ae6e9577c9877fbb77908ccf1652d212800132a9eba02ef"
 metafile = true
 
 [[files]]

--- a/versions/1.21.4/mods/better-selection.pw.toml
+++ b/versions/1.21.4/mods/better-selection.pw.toml
@@ -1,13 +1,13 @@
 name = "Better Selection"
-filename = "better-selection-1.6.7.jar"
+filename = "better-selection-1.6.8.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/iZeFi2vX/better-selection-1.6.7.jar"
+url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/XjB8wIwx/better-selection-1.6.8.jar"
 hash-format = "sha512"
-hash = "215b45c43ef391074d651dd835562aa41d3cb5e9ecea6b918e65944ea04b162884767824ba455a693bd51050c011f5a5d7f3711650903e753b77ca9f2b522daa"
+hash = "181c466adcba2f7094c1ef9ff13aea9f79d6306f6f2d2983c97145449b7a9b69d861a0eedba3b30fa181ca20627e02402ef648989b1a6e27c6b77d93e8d91fb7"
 
 [update]
 [update.modrinth]
 mod-id = "xIpcAYJL"
-version = "iZeFi2vX"
+version = "XjB8wIwx"

--- a/versions/1.21.4/mods/chatpatches.pw.toml
+++ b/versions/1.21.4/mods/chatpatches.pw.toml
@@ -1,13 +1,13 @@
 name = "Chat Patches"
-filename = "chatpatches-8.0-alpha.1+1.21.4-fabric.jar"
+filename = "chatpatches-8.0-alpha.2+1.21.4-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/IQYIa2mK/chatpatches-8.0-alpha.1%2B1.21.4-fabric.jar"
+url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/QiuZwSHM/chatpatches-8.0-alpha.2%2B1.21.4-fabric.jar"
 hash-format = "sha512"
-hash = "6bf58a072bd3d14d4636dccec3b916947c3a0ca8c71747f5dcf460ead5ce382939f1de5c85f5c03048a130aa6646d5a9ef0571a8286114442117347322d3253b"
+hash = "c81d847b3dbd6ffaa6a7b75954f690afca08aed5951e0921f0ae0a02b8fdec7565146d6e3851712e4d73890eb8dc3fb94f79604fde29a7fca40578bc700484b7"
 
 [update]
 [update.modrinth]
 mod-id = "MOqt4Z5n"
-version = "IQYIa2mK"
+version = "QiuZwSHM"

--- a/versions/1.21.4/mods/default-options.pw.toml
+++ b/versions/1.21.4/mods/default-options.pw.toml
@@ -1,13 +1,13 @@
 name = "Default Options"
-filename = "defaultoptions-fabric-1.21.4-21.4.4.jar"
+filename = "defaultoptions-fabric-1.21.4-21.4.5.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/WEg59z5b/versions/OGdQkWTP/defaultoptions-fabric-1.21.4-21.4.4.jar"
+url = "https://cdn.modrinth.com/data/WEg59z5b/versions/oIHjFeUL/defaultoptions-fabric-1.21.4-21.4.5.jar"
 hash-format = "sha512"
-hash = "23f5b316b7add1677e15bb3956e589247520222246d92f6d12858b9ebeb8f7db84c200b406fec4fa5fa74ef06ee5b58955faeafdc16776ae5c8b0964b58812bd"
+hash = "02fe4db2ef39d347f0a6efbcc19305e4dc627dbec3b93d76a0d20bd340ea3b3ecab3acfef39e5a4f752e000ae9c20e0ae45688e56783b65a90c999a12aaff94d"
 
 [update]
 [update.modrinth]
 mod-id = "WEg59z5b"
-version = "OGdQkWTP"
+version = "oIHjFeUL"

--- a/versions/1.21.4/mods/magiclib.pw.toml
+++ b/versions/1.21.4/mods/magiclib.pw.toml
@@ -1,13 +1,13 @@
 name = "MagicLib Dev"
-filename = "MagicLib-mc1.21.4-fabric-0.8.721-beta.jar"
+filename = "MagicLib-mc1.21.4-fabric-0.8.722-beta.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/JOGZQCse/versions/RKyDzlqQ/MagicLib-mc1.21.4-fabric-0.8.721-beta.jar"
+url = "https://cdn.modrinth.com/data/JOGZQCse/versions/pjfxNsbO/MagicLib-mc1.21.4-fabric-0.8.722-beta.jar"
 hash-format = "sha512"
-hash = "f98ab3ae483e9cac83c03d5bdac35326e5bd133f1a07e9d2b9fd035ba6e319890913b9d3afa4e3c5d7c65a22e1b01b7ece9a1de424a4ce7e3d4ce46b6a7fa725"
+hash = "0c3b4c7785a1371e298bc7933c93ac74be3e70fa474ef894071a0c89e8d1564f35cf923248de511811ad785d77e387ccc5eda8aa3d9d8c8c24c990d697b09c25"
 
 [update]
 [update.modrinth]
 mod-id = "JOGZQCse"
-version = "RKyDzlqQ"
+version = "pjfxNsbO"

--- a/versions/1.21.4/mods/packet-fixer.pw.toml
+++ b/versions/1.21.4/mods/packet-fixer.pw.toml
@@ -1,13 +1,13 @@
 name = "Packet Fixer"
-filename = "packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+filename = "packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/c7m1mi73/versions/xIgAknUv/packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+url = "https://cdn.modrinth.com/data/c7m1mi73/versions/LL1w2rTw/packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 hash-format = "sha512"
-hash = "797fe40eb8f1be0d657f44a00a72e2a07dcda88d9e7a6e2f944ae3b6fe70491508410b4748b6c8b55d8f95c5e9867e06ab7b505372b738dbd54f0e74b50d5c82"
+hash = "639c010b5c05e8ec964a8ad1b5736302a02ee03f2f5f97e076df9c5aa23d94b52752e0998356b223f9bbf7c426a433bb89d3a38e24efd062a8de126464f37f59"
 
 [update]
 [update.modrinth]
 mod-id = "c7m1mi73"
-version = "xIgAknUv"
+version = "LL1w2rTw"

--- a/versions/1.21.4/pack.toml
+++ b/versions/1.21.4/pack.toml
@@ -1,12 +1,12 @@
 name = "LunarFox"
 author = "OrzMiku"
-version = "1.1.8+mc1.21.4"
+version = "1.1.9+mc1.21.4"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "2f6e0fd509c40b95399bc2a5a8fb190b928e39d0ae3cd4ef27d6d06dfd5c4435"
+hash = "c02de787e2124f62e367f85defefdf200b13eff31f4edf234b4c2bb0fad408ca"
 
 [versions]
 fabric = "0.16.14"

--- a/versions/1.21.5/index.toml
+++ b/versions/1.21.5/index.toml
@@ -140,7 +140,7 @@ metafile = true
 
 [[files]]
 file = "mods/better-selection.pw.toml"
-hash = "1834c4dda40a11f275bb16180e29f505fb27bf0a1adbe69885d88a9990196bd5"
+hash = "5f13e2470d769f613652ff4378a31c86b5915fe67032c94c1be5aeed06610b4d"
 metafile = true
 
 [[files]]
@@ -190,7 +190,7 @@ metafile = true
 
 [[files]]
 file = "mods/chatpatches.pw.toml"
-hash = "91bfb35359acf9f62916ff73bea5f236a138951d5426aae41b8417f1b5ee0b93"
+hash = "9fe52652e724da96ee6cd215166eb5b4b39c6a8d758c6e225c05e95365b620f0"
 metafile = true
 
 [[files]]
@@ -220,7 +220,7 @@ metafile = true
 
 [[files]]
 file = "mods/default-options.pw.toml"
-hash = "6e4620cfa816039cbf327fe8152fe7890a590a1354c28b55d39205c01c2a73ef"
+hash = "641201578a6f36243f4169ec9f6b63b439efba0180dea0afebc299d1d0372494"
 metafile = true
 
 [[files]]
@@ -385,7 +385,7 @@ metafile = true
 
 [[files]]
 file = "mods/magiclib.pw.toml"
-hash = "e19d3556a837aa73194d55b7b391eeed27fd9482f36291232641eab96e6482c0"
+hash = "c3ddc34e0351a4028004533157dd245fcc76090f1668a7c84014a45cc0dd6329"
 metafile = true
 
 [[files]]
@@ -464,7 +464,7 @@ metafile = true
 
 [[files]]
 file = "mods/packet-fixer.pw.toml"
-hash = "2042bf4b5b3bdd0faafa8310673ab3a6115240f4f36e5e2ff38c7d933e483637"
+hash = "4bf091a6947c83041ae6e9577c9877fbb77908ccf1652d212800132a9eba02ef"
 metafile = true
 
 [[files]]

--- a/versions/1.21.5/mods/better-selection.pw.toml
+++ b/versions/1.21.5/mods/better-selection.pw.toml
@@ -1,13 +1,13 @@
 name = "Better Selection"
-filename = "better-selection-1.6.7.jar"
+filename = "better-selection-1.6.8.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/iZeFi2vX/better-selection-1.6.7.jar"
+url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/XjB8wIwx/better-selection-1.6.8.jar"
 hash-format = "sha512"
-hash = "215b45c43ef391074d651dd835562aa41d3cb5e9ecea6b918e65944ea04b162884767824ba455a693bd51050c011f5a5d7f3711650903e753b77ca9f2b522daa"
+hash = "181c466adcba2f7094c1ef9ff13aea9f79d6306f6f2d2983c97145449b7a9b69d861a0eedba3b30fa181ca20627e02402ef648989b1a6e27c6b77d93e8d91fb7"
 
 [update]
 [update.modrinth]
 mod-id = "xIpcAYJL"
-version = "iZeFi2vX"
+version = "XjB8wIwx"

--- a/versions/1.21.5/mods/chatpatches.pw.toml
+++ b/versions/1.21.5/mods/chatpatches.pw.toml
@@ -1,13 +1,13 @@
 name = "Chat Patches"
-filename = "chatpatches-8.0-alpha.1+1.21.5-fabric.jar"
+filename = "chatpatches-8.0-alpha.2+1.21.5-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/FdfiSqCi/chatpatches-8.0-alpha.1%2B1.21.5-fabric.jar"
+url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/K76fJMQg/chatpatches-8.0-alpha.2%2B1.21.5-fabric.jar"
 hash-format = "sha512"
-hash = "ede6d643f24e8ee85025afa1931780cc357a7982c2f87d92196d03329cd7aaea9333f019a7edb86ff2fcfc0037984e38852fe91761db7815f370c7c9ed1d131a"
+hash = "6d59c116ae3fcab1079a4e58715dc3c452b5b0b48460aa5f5ccf565a3fdcd087272d1f3db32d02e9a6cdee51e7a8314d23d1ef417b8158d9110f0ade99fbaf1d"
 
 [update]
 [update.modrinth]
 mod-id = "MOqt4Z5n"
-version = "FdfiSqCi"
+version = "K76fJMQg"

--- a/versions/1.21.5/mods/default-options.pw.toml
+++ b/versions/1.21.5/mods/default-options.pw.toml
@@ -1,13 +1,13 @@
 name = "Default Options"
-filename = "defaultoptions-fabric-1.21.5-21.5.3.jar"
+filename = "defaultoptions-fabric-1.21.5-21.5.4.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/WEg59z5b/versions/1WcfjGqW/defaultoptions-fabric-1.21.5-21.5.3.jar"
+url = "https://cdn.modrinth.com/data/WEg59z5b/versions/v06zNwdK/defaultoptions-fabric-1.21.5-21.5.4.jar"
 hash-format = "sha512"
-hash = "8f0daa09430c06165eb17f00cc6e4b100cdb5c292c70519eaaa914f445bfbeeb347da0967ed271eb30b5257eeb417a91818f9c6f85a51a635ea8adc8b35952a0"
+hash = "0b480df63963be1303b21a694f7833edca5e85d80431e3db283914e010d32b6cfbff02ba92ea1f3c655ee2ab77d3d459131637f4d8babeeaaa5bb618c228883e"
 
 [update]
 [update.modrinth]
 mod-id = "WEg59z5b"
-version = "1WcfjGqW"
+version = "v06zNwdK"

--- a/versions/1.21.5/mods/magiclib.pw.toml
+++ b/versions/1.21.5/mods/magiclib.pw.toml
@@ -1,13 +1,13 @@
 name = "MagicLib Dev"
-filename = "MagicLib-mc1.21.5-fabric-0.8.721-beta.jar"
+filename = "MagicLib-mc1.21.5-fabric-0.8.722-beta.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/JOGZQCse/versions/ffwLKP20/MagicLib-mc1.21.5-fabric-0.8.721-beta.jar"
+url = "https://cdn.modrinth.com/data/JOGZQCse/versions/Bywl53vI/MagicLib-mc1.21.5-fabric-0.8.722-beta.jar"
 hash-format = "sha512"
-hash = "423a679a80c25acf8aa95444adc1a27474fcf7f5b16e6b6db961ef9da15eedc4ae7a84b592c09314247e7e30c50f0f30de00163a456d0790303a82efa6ebae30"
+hash = "0c5ed7beaac2307d60e7a6e6feaaac07ed0228a8898ba57c57bc0447af5b4416bc253131699ecf3510db46eb750e9b9052c2310f63a4d3d11aa0188163c0ebed"
 
 [update]
 [update.modrinth]
 mod-id = "JOGZQCse"
-version = "ffwLKP20"
+version = "Bywl53vI"

--- a/versions/1.21.5/mods/packet-fixer.pw.toml
+++ b/versions/1.21.5/mods/packet-fixer.pw.toml
@@ -1,13 +1,13 @@
 name = "Packet Fixer"
-filename = "packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+filename = "packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/c7m1mi73/versions/xIgAknUv/packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+url = "https://cdn.modrinth.com/data/c7m1mi73/versions/LL1w2rTw/packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 hash-format = "sha512"
-hash = "797fe40eb8f1be0d657f44a00a72e2a07dcda88d9e7a6e2f944ae3b6fe70491508410b4748b6c8b55d8f95c5e9867e06ab7b505372b738dbd54f0e74b50d5c82"
+hash = "639c010b5c05e8ec964a8ad1b5736302a02ee03f2f5f97e076df9c5aa23d94b52752e0998356b223f9bbf7c426a433bb89d3a38e24efd062a8de126464f37f59"
 
 [update]
 [update.modrinth]
 mod-id = "c7m1mi73"
-version = "xIgAknUv"
+version = "LL1w2rTw"

--- a/versions/1.21.5/pack.toml
+++ b/versions/1.21.5/pack.toml
@@ -1,12 +1,12 @@
 name = "LunarFox"
 author = "OrzMiku"
-version = "1.1.8+mc1.21.5"
+version = "1.1.9+mc1.21.5"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "cde5cfe28009edc5b4dccbfdf9060192725b949f04cfda25b2d32ac64799ad08"
+hash = "bb10328c7ea52c49605a7cfa58a47283e3e061b90079527e62d5ffb82f491d6b"
 
 [versions]
 fabric = "0.16.14"

--- a/versions/1.21.6/index.toml
+++ b/versions/1.21.6/index.toml
@@ -115,7 +115,7 @@ metafile = true
 
 [[files]]
 file = "mods/better-selection.pw.toml"
-hash = "1834c4dda40a11f275bb16180e29f505fb27bf0a1adbe69885d88a9990196bd5"
+hash = "5f13e2470d769f613652ff4378a31c86b5915fe67032c94c1be5aeed06610b4d"
 metafile = true
 
 [[files]]
@@ -165,7 +165,7 @@ metafile = true
 
 [[files]]
 file = "mods/chatpatches.pw.toml"
-hash = "6f86be23e8d16464eb5241ba4bfda96f6a4b1feb37ba31c9a34a9d51aeb44e5f"
+hash = "f717b69e969c49a6c94971944b66a36b01fda15f70cf590744b1c91b31efc276"
 metafile = true
 
 [[files]]
@@ -185,7 +185,7 @@ metafile = true
 
 [[files]]
 file = "mods/controlling.pw.toml"
-hash = "0cfbce797ea458575a8880506191d08a3be202c5bbdf8ba64cec2a5758bb9d77"
+hash = "5bbd4a7721ea85f8294bf1853544ae717e88eeb2bc858e624529a567a3aa07d7"
 metafile = true
 
 [[files]]
@@ -410,7 +410,7 @@ metafile = true
 
 [[files]]
 file = "mods/packet-fixer.pw.toml"
-hash = "2042bf4b5b3bdd0faafa8310673ab3a6115240f4f36e5e2ff38c7d933e483637"
+hash = "4bf091a6947c83041ae6e9577c9877fbb77908ccf1652d212800132a9eba02ef"
 metafile = true
 
 [[files]]
@@ -441,6 +441,11 @@ metafile = true
 [[files]]
 file = "mods/reeses-sodium-options.pw.toml"
 hash = "88f9a71bf06f4959b220abab8542e4763747903e9e5ef150c38ae79c83870077"
+metafile = true
+
+[[files]]
+file = "mods/rei.pw.toml"
+hash = "1614366f37814b1f1e9248e055b576cbd88d6463164d2bd8b5654b12f58e7cea"
 metafile = true
 
 [[files]]

--- a/versions/1.21.6/mods/better-selection.pw.toml
+++ b/versions/1.21.6/mods/better-selection.pw.toml
@@ -1,13 +1,13 @@
 name = "Better Selection"
-filename = "better-selection-1.6.7.jar"
+filename = "better-selection-1.6.8.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/iZeFi2vX/better-selection-1.6.7.jar"
+url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/XjB8wIwx/better-selection-1.6.8.jar"
 hash-format = "sha512"
-hash = "215b45c43ef391074d651dd835562aa41d3cb5e9ecea6b918e65944ea04b162884767824ba455a693bd51050c011f5a5d7f3711650903e753b77ca9f2b522daa"
+hash = "181c466adcba2f7094c1ef9ff13aea9f79d6306f6f2d2983c97145449b7a9b69d861a0eedba3b30fa181ca20627e02402ef648989b1a6e27c6b77d93e8d91fb7"
 
 [update]
 [update.modrinth]
 mod-id = "xIpcAYJL"
-version = "iZeFi2vX"
+version = "XjB8wIwx"

--- a/versions/1.21.6/mods/chatpatches.pw.toml
+++ b/versions/1.21.6/mods/chatpatches.pw.toml
@@ -1,13 +1,13 @@
 name = "Chat Patches"
-filename = "chatpatches-8.0-alpha.1+1.21.6-fabric.jar"
+filename = "chatpatches-8.0-alpha.2+1.21.6-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/7M07nl8Y/chatpatches-8.0-alpha.1%2B1.21.6-fabric.jar"
+url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/i4TEPIac/chatpatches-8.0-alpha.2%2B1.21.6-fabric.jar"
 hash-format = "sha512"
-hash = "39b42f8a9efdfa8097f1879e04c27280596ff1d950efaba28f4719ea63d5b84796a42d742a77fba94af2faec30ccbe04870d13de095b190bc45534a8c34d9355"
+hash = "6c3fef9045034b2b320d1284023209ea8d520b377cfffdd4e345825c76461f5fc2790feefeffef9eb52eced214b73142053c2e459181180fe91daa57de2bd743"
 
 [update]
 [update.modrinth]
 mod-id = "MOqt4Z5n"
-version = "7M07nl8Y"
+version = "i4TEPIac"

--- a/versions/1.21.6/mods/controlling.pw.toml
+++ b/versions/1.21.6/mods/controlling.pw.toml
@@ -1,13 +1,13 @@
 name = "Controlling"
-filename = "Controlling-fabric-1.21.6-24.0.1.jar"
+filename = "Controlling-fabric-1.21.6-24.0.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/xv94TkTM/versions/IuGLMYHi/Controlling-fabric-1.21.6-24.0.1.jar"
+url = "https://cdn.modrinth.com/data/xv94TkTM/versions/IzCLUaM4/Controlling-fabric-1.21.6-24.0.2.jar"
 hash-format = "sha512"
-hash = "9dd09d2b35fd910af08e8856b2c5e8fc7f297ab353707f31c2bf06762970cf37f440f1f6369d4c9b51be4dd81a66b8607f1722a46ad235ee27b60456ddebd7b9"
+hash = "33a9f32520260616f8e033776221aaeacdb807243db3fe2fd752e33de54433462273f78bf94b6adfedb8d70ccfa4a74c0da94f93981b0bc4dce539e06fee4560"
 
 [update]
 [update.modrinth]
 mod-id = "xv94TkTM"
-version = "IuGLMYHi"
+version = "IzCLUaM4"

--- a/versions/1.21.6/mods/packet-fixer.pw.toml
+++ b/versions/1.21.6/mods/packet-fixer.pw.toml
@@ -1,13 +1,13 @@
 name = "Packet Fixer"
-filename = "packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+filename = "packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/c7m1mi73/versions/xIgAknUv/packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+url = "https://cdn.modrinth.com/data/c7m1mi73/versions/LL1w2rTw/packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 hash-format = "sha512"
-hash = "797fe40eb8f1be0d657f44a00a72e2a07dcda88d9e7a6e2f944ae3b6fe70491508410b4748b6c8b55d8f95c5e9867e06ab7b505372b738dbd54f0e74b50d5c82"
+hash = "639c010b5c05e8ec964a8ad1b5736302a02ee03f2f5f97e076df9c5aa23d94b52752e0998356b223f9bbf7c426a433bb89d3a38e24efd062a8de126464f37f59"
 
 [update]
 [update.modrinth]
 mod-id = "c7m1mi73"
-version = "xIgAknUv"
+version = "LL1w2rTw"

--- a/versions/1.21.6/mods/rei.pw.toml
+++ b/versions/1.21.6/mods/rei.pw.toml
@@ -1,0 +1,13 @@
+name = "Roughly Enough Items (REI)"
+filename = "RoughlyEnoughItems-20.0.810-fabric.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/nfn13YXA/versions/t6ocxwV5/RoughlyEnoughItems-20.0.810-fabric.jar"
+hash-format = "sha512"
+hash = "2870b06702ea7d0369e9a4c036c00b2ff87f69b4a925dc8c1b09012c715c1faf396a47100191d7a5c792e47618fe67e32f1055c3d3f6441ae8189b860303b47d"
+
+[update]
+[update.modrinth]
+mod-id = "nfn13YXA"
+version = "t6ocxwV5"

--- a/versions/1.21.6/pack.toml
+++ b/versions/1.21.6/pack.toml
@@ -1,12 +1,12 @@
 name = "LunarFox"
 author = "OrzMiku"
-version = "1.1.8+mc1.21.6"
+version = "1.1.9+mc1.21.6"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "43ddf6b687f289523c5fc4a9c1be02fe234d37db4de1c35dd549fc1bd978c206"
+hash = "a42f97ae90fd0c4106ba0c5a39988e39b4b2af36a3439b353bfb6a959f81271d"
 
 [versions]
 fabric = "0.16.14"

--- a/versions/1.21.7/index.toml
+++ b/versions/1.21.7/index.toml
@@ -76,7 +76,7 @@ metafile = true
 
 [[files]]
 file = "mods/architectury-api.pw.toml"
-hash = "47d1dc015b07695d8d3107cb12aa75e154ed0a9c0216a69fed7d221857f6ad7d"
+hash = "832691489ab19e2f0a4b81b77c143a8dceb5f3f395cdee96bcddd893fb01b363"
 metafile = true
 
 [[files]]
@@ -106,7 +106,7 @@ metafile = true
 
 [[files]]
 file = "mods/better-selection.pw.toml"
-hash = "1834c4dda40a11f275bb16180e29f505fb27bf0a1adbe69885d88a9990196bd5"
+hash = "5f13e2470d769f613652ff4378a31c86b5915fe67032c94c1be5aeed06610b4d"
 metafile = true
 
 [[files]]
@@ -151,7 +151,7 @@ metafile = true
 
 [[files]]
 file = "mods/chatpatches.pw.toml"
-hash = "407997b50bf52aebec1f8d1017cb92e99bda2d01fac4fb5511ca5f69cb22ff8d"
+hash = "03ca5e8340966f21df75dc47b807f974ca57f9d57dbb56c8f8f118df843b6cae"
 metafile = true
 
 [[files]]
@@ -171,7 +171,7 @@ metafile = true
 
 [[files]]
 file = "mods/controlling.pw.toml"
-hash = "df3cbb0cbd2d921720fcc0033b66b7639f9bbd039b5d7fbdfe98f502869486bc"
+hash = "ba3fce3844b6383543275c04ba0811d09cade4eb8471de9764ead2989e1dfbf1"
 metafile = true
 
 [[files]]
@@ -386,7 +386,7 @@ metafile = true
 
 [[files]]
 file = "mods/packet-fixer.pw.toml"
-hash = "2042bf4b5b3bdd0faafa8310673ab3a6115240f4f36e5e2ff38c7d933e483637"
+hash = "4bf091a6947c83041ae6e9577c9877fbb77908ccf1652d212800132a9eba02ef"
 metafile = true
 
 [[files]]
@@ -422,6 +422,11 @@ metafile = true
 [[files]]
 file = "mods/reeses-sodium-options.pw.toml"
 hash = "88f9a71bf06f4959b220abab8542e4763747903e9e5ef150c38ae79c83870077"
+metafile = true
+
+[[files]]
+file = "mods/rei.pw.toml"
+hash = "1614366f37814b1f1e9248e055b576cbd88d6463164d2bd8b5654b12f58e7cea"
 metafile = true
 
 [[files]]

--- a/versions/1.21.7/mods/architectury-api.pw.toml
+++ b/versions/1.21.7/mods/architectury-api.pw.toml
@@ -1,13 +1,13 @@
 name = "Architectury API"
-filename = "architectury-17.0.6-fabric.jar"
+filename = "architectury-17.0.8-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/VxCkJjz7/architectury-17.0.6-fabric.jar"
+url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/XcJm5LH4/architectury-17.0.8-fabric.jar"
 hash-format = "sha512"
-hash = "5abc7591f6f4c538b8f52c4b9fceab057d84d24d3044efa6aa6455a061689c9be39439c260b62231f1b963156dd8f4447c147bb2eea45e16b4f8266a4bde988b"
+hash = "7965ed7140c9f50cfcf8cf9b415de90497ae44ea4fb6dfe21704c6eba4210d0a34a4a0b0b6baf8b3e9d3b1cb70d0df79ef1ba93d04b5557f09a754959ac9c8b0"
 
 [update]
 [update.modrinth]
 mod-id = "lhGA9TYQ"
-version = "VxCkJjz7"
+version = "XcJm5LH4"

--- a/versions/1.21.7/mods/better-selection.pw.toml
+++ b/versions/1.21.7/mods/better-selection.pw.toml
@@ -1,13 +1,13 @@
 name = "Better Selection"
-filename = "better-selection-1.6.7.jar"
+filename = "better-selection-1.6.8.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/iZeFi2vX/better-selection-1.6.7.jar"
+url = "https://cdn.modrinth.com/data/xIpcAYJL/versions/XjB8wIwx/better-selection-1.6.8.jar"
 hash-format = "sha512"
-hash = "215b45c43ef391074d651dd835562aa41d3cb5e9ecea6b918e65944ea04b162884767824ba455a693bd51050c011f5a5d7f3711650903e753b77ca9f2b522daa"
+hash = "181c466adcba2f7094c1ef9ff13aea9f79d6306f6f2d2983c97145449b7a9b69d861a0eedba3b30fa181ca20627e02402ef648989b1a6e27c6b77d93e8d91fb7"
 
 [update]
 [update.modrinth]
 mod-id = "xIpcAYJL"
-version = "iZeFi2vX"
+version = "XjB8wIwx"

--- a/versions/1.21.7/mods/chatpatches.pw.toml
+++ b/versions/1.21.7/mods/chatpatches.pw.toml
@@ -1,13 +1,13 @@
 name = "Chat Patches"
-filename = "chatpatches-8.0-alpha.1+1.21.7-fabric.jar"
+filename = "chatpatches-8.0-alpha.2+1.21.8-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/TPGiNuiM/chatpatches-8.0-alpha.1%2B1.21.7-fabric.jar"
+url = "https://cdn.modrinth.com/data/MOqt4Z5n/versions/hPqE3W8Q/chatpatches-8.0-alpha.2%2B1.21.8-fabric.jar"
 hash-format = "sha512"
-hash = "234c53f1aa6e48a6a1a4357eb3c2db07456a685e1c326e78652c53efb4262b8b25e0ccda62376c0aa87c39258d177fdc47279ac46e5bf1e5dafcb8e8f179a963"
+hash = "ca025809fa20746dbd77202fc2e49a0fd45894fc8d83a139588de9b9cc43b3d03a4c384b0b7ee0b78e67c548c4e148f6e196f068983b678c5de8e584b99a687c"
 
 [update]
 [update.modrinth]
 mod-id = "MOqt4Z5n"
-version = "TPGiNuiM"
+version = "hPqE3W8Q"

--- a/versions/1.21.7/mods/controlling.pw.toml
+++ b/versions/1.21.7/mods/controlling.pw.toml
@@ -1,13 +1,13 @@
 name = "Controlling"
-filename = "Controlling-fabric-1.21.7-25.0.1.jar"
+filename = "Controlling-fabric-1.21.7-25.0.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/xv94TkTM/versions/crTvOIlD/Controlling-fabric-1.21.7-25.0.1.jar"
+url = "https://cdn.modrinth.com/data/xv94TkTM/versions/rJyUf9kw/Controlling-fabric-1.21.7-25.0.2.jar"
 hash-format = "sha512"
-hash = "66c500f2de1dcf6e0a1f0cf37793a411478d1ce00ffc1c6e961725679c7fe013f2f1684908b7f8cbc33fc9a081e304a33ffc4b6e63afb8c1dd01269741b639f7"
+hash = "b7eeaf973c6ed571167f879be8a6057a5525529d475725347d9ef4175c6803cdb5738dfe364a0f811c9bdb6da59c56c35a0fb46a2f8de5c10a06162cef6ed4ad"
 
 [update]
 [update.modrinth]
 mod-id = "xv94TkTM"
-version = "crTvOIlD"
+version = "rJyUf9kw"

--- a/versions/1.21.7/mods/packet-fixer.pw.toml
+++ b/versions/1.21.7/mods/packet-fixer.pw.toml
@@ -1,13 +1,13 @@
 name = "Packet Fixer"
-filename = "packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+filename = "packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/c7m1mi73/versions/xIgAknUv/packetfixer-3.1.4-1.20.5-1.21.7-merged.jar"
+url = "https://cdn.modrinth.com/data/c7m1mi73/versions/LL1w2rTw/packetfixer-3.1.4-1.20.5-1.21.X-merged.jar"
 hash-format = "sha512"
-hash = "797fe40eb8f1be0d657f44a00a72e2a07dcda88d9e7a6e2f944ae3b6fe70491508410b4748b6c8b55d8f95c5e9867e06ab7b505372b738dbd54f0e74b50d5c82"
+hash = "639c010b5c05e8ec964a8ad1b5736302a02ee03f2f5f97e076df9c5aa23d94b52752e0998356b223f9bbf7c426a433bb89d3a38e24efd062a8de126464f37f59"
 
 [update]
 [update.modrinth]
 mod-id = "c7m1mi73"
-version = "xIgAknUv"
+version = "LL1w2rTw"

--- a/versions/1.21.7/mods/rei.pw.toml
+++ b/versions/1.21.7/mods/rei.pw.toml
@@ -1,0 +1,13 @@
+name = "Roughly Enough Items (REI)"
+filename = "RoughlyEnoughItems-20.0.810-fabric.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/nfn13YXA/versions/t6ocxwV5/RoughlyEnoughItems-20.0.810-fabric.jar"
+hash-format = "sha512"
+hash = "2870b06702ea7d0369e9a4c036c00b2ff87f69b4a925dc8c1b09012c715c1faf396a47100191d7a5c792e47618fe67e32f1055c3d3f6441ae8189b860303b47d"
+
+[update]
+[update.modrinth]
+mod-id = "nfn13YXA"
+version = "t6ocxwV5"

--- a/versions/1.21.7/pack.toml
+++ b/versions/1.21.7/pack.toml
@@ -1,12 +1,12 @@
 name = "LunarFox"
 author = "OrzMiku"
-version = "1.1.8-beta.1+mc1.21.7"
+version = "1.1.9+mc1.21.7"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "c9d0964796b043f3f2b8b76fc95b51e88d0ecf61cdefdac6a6bb7a4458892ce4"
+hash = "815af56eeee847bfe1fd719606540fe4cdae09406069e4359097891a469a752f"
 
 [versions]
 fabric = "0.16.14"


### PR DESCRIPTION
- 20250725 常规更新检测
- (1.21.6/1.21.7) 添加 REI 模组